### PR TITLE
chore: better display reference link

### DIFF
--- a/mengxiq/src/component/QueueItem.tsx
+++ b/mengxiq/src/component/QueueItem.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react';
-import { priorityLevelMap, priorityLevelMapKeys } from "../model/Priority"
+import { priorityLevelMap, priorityLevelMapKeys } from "../model/Priority";
+import { getHostname } from '../utils';
 
 function QueueItem(
   props: {
@@ -136,7 +137,7 @@ function QueueItem(
               rel="noopener noreferrer"
               className="text-blue-600 hover:text-blue-800 text-sm inline-flex items-center gap-1 hover:underline"
             >
-              🔗 Reference Link
+              🔗 Ref Link: {getHostname(props.link)}
             </a>
           )}
         </div>

--- a/mengxiq/src/component/Report.tsx
+++ b/mengxiq/src/component/Report.tsx
@@ -3,6 +3,7 @@ import { Report as ReportType, ReportItem, getReportDb, current_report_id } from
 import { listQueuesDb } from '../db/JsonServer';
 import { priorityLevelMap } from '../model/Priority';
 import { PriorityQueue } from '../model/PriorityQueue';
+import { getHostname } from '../utils';
 
 function Report(): JSX.Element {
   const [report, setReport] = useState<ReportType | null>(null);
@@ -377,7 +378,7 @@ function Report(): JSX.Element {
                           rel="noopener noreferrer"
                           className="text-blue-600 hover:text-blue-800 underline text-sm break-all"
                         >
-                          🔗 {item.link}
+                          🔗 Ref Link: {getHostname(item.link)}
                         </a>
                       </div>
                     )}

--- a/mengxiq/src/utils.ts
+++ b/mengxiq/src/utils.ts
@@ -1,0 +1,13 @@
+/**
+ * Extract hostname from a URL
+ * @param url - The URL to extract hostname from
+ * @returns The hostname, or the original URL if parsing fails
+ */
+export function getHostname(url: string): string {
+  try {
+    const urlObj = new URL(url);
+    return urlObj.hostname;
+  } catch {
+    return url; // If URL parsing fails, return the original URL
+  }
+}


### PR DESCRIPTION
## Before
<img width="845" height="222" alt="image" src="https://github.com/user-attachments/assets/5ac1a706-9b70-41c0-a024-6b217f2f8d3f" />
<img width="842" height="227" alt="image" src="https://github.com/user-attachments/assets/043bd039-5a8a-49dd-a61a-d6f447d775de" />

## After
<img width="843" height="224" alt="image" src="https://github.com/user-attachments/assets/c732f603-43d2-4163-b1df-6a289fa0d26c" />
<img width="830" height="209" alt="image" src="https://github.com/user-attachments/assets/e2d2b119-d5fe-4f6f-b970-dc712b064257" />
